### PR TITLE
Fix altered font size if `\ISSNPageSubitle` was defined

### DIFF
--- a/TemplateFiles/Template.tex
+++ b/TemplateFiles/Template.tex
@@ -166,7 +166,7 @@
 
 \noindent\textbf{\ISSNPageTitle}\\
 \ifdefined \ISSNPageSubitle \if \ISSNPageSubitle\empty\else
-    \noindent\footnotesize\textit{\ISSNPageSubitle}\\
+    {\noindent\footnotesize\textit{\ISSNPageSubitle}}\\
 \fi\fi\\
 {\textsc{\ISSNPageName}}
 \vspace{4.0 cm}\\


### PR DESCRIPTION
Beforehand, the font size of the text paragraphs in the entire document was altered if \ISSNPageSubitle was defined. This should be fixed now.

This sh**ty detail costed me hours unfortunately. :(