### PR TITLE
Update GlobalSettings.sty

### DIFF
--- a/TemplateFiles/GlobalSettings.sty
+++ b/TemplateFiles/GlobalSettings.sty
@@ -47,7 +47,7 @@
 	\def\thesectiondis{\alph{\thesectiondis}.} 
 	\renewcommand\thesection{Appendix~\Alph{section}}
 	\def\thesubsectiondis{\alph{\thesubsectiondis}.} 
-	\renewcommand\thesubsection{\Alph{section}.\alph{subsection}}
+	\renewcommand\thesubsection{\Alph{section}.\arabic{subsection}}
 }
 
 % Define what to put in toc for section inside appendix and how to put it


### PR DESCRIPTION
Fix to make subsection enumeration in appendix match that of table of contents. Either lines 50 and 71 in \appendixpreamble and \appendixsubsection should both contain Alph.arabic or Alph.alph. 