### PR TITLE
Fix section name carry over to next paper

### DIFF
--- a/TemplateFiles/AddMyPapers.sty
+++ b/TemplateFiles/AddMyPapers.sty
@@ -32,6 +32,7 @@
 \newcommand{\includepaper}[1]{
     \graphicspath{ {YourThesis/papers/#1/} }
 	\begin{refsection}
+	\markboth{}{}
 	\input{YourThesis/papers/#1/info}
 	\paper[\theshortpapertitle]{\thelongpapertitle}
 	%\paperauthor{\thepaperauthor}


### PR DESCRIPTION
Currently, the section name in the header is carried over between papers if the first page of a paper does not start a new section. For instance, if the first page only has a figure and abstract, the header will say "References". Now it will simply be empty. Potentially one would like it to say Abstract instead, but not sure.

Before fix
![image](https://github.com/user-attachments/assets/d741126b-4078-4eeb-9a07-9e1a468eb8aa)


After fix
![image](https://github.com/user-attachments/assets/7fdb4db7-fd92-4a28-8ccf-f65d842e21be)
